### PR TITLE
Code Fefactor on PSD2 Issue

### DIFF
--- a/v3/lints/cabf_ev/lint_ev_orgid_inconsistent_subj_and_ext.go
+++ b/v3/lints/cabf_ev/lint_ev_orgid_inconsistent_subj_and_ext.go
@@ -20,6 +20,7 @@
 package cabf_ev
 
 import (
+	"fmt"
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/v3/lint"
 	"github.com/zmap/zlint/v3/util"
@@ -43,47 +44,46 @@ func init() {
 
 // According to EVGs 9.2.8
 type OrganizationIdentifier struct {
-	Scheme    string
-	Country   string
-	State     string
-	Reference string
+	ParseAsPSD bool
+	Scheme     string
+	Country    string
+	State      string
+	Reference  string
 }
 
-// This is according to the EVG (stricter than ETSI EN 319 412-1)
-var OrgIdPattern = `^(?P<scheme>[A-Z]{3})(?P<country>[A-Z]{2})(?:\+(?P<state>[A-Z]{2}))?\-(?P<reference>.+)$`
-var PsdOrgIdPattern = `^(?P<scheme>[A-Z]{3})(?P<country>[A-Z]{2})(?:\+(?P<state>[A-Z]{2}))?\-(?P<nca>[A-Z]*)\-(?P<reference>.+)$`
-
-func ParseOrgId(orgIdString string, orgId *OrganizationIdentifier, psdScheme bool) error {
-
-	if psdScheme {
-		OrgIdPattern = PsdOrgIdPattern
+func (o OrganizationIdentifier) Parse(orgId string) (OrganizationIdentifier, error) {
+	re := o.regexForOrgID()
+	if !re.MatchString(orgId) {
+		return o, errors.New(fmt.Sprintf("Cannot parse organizationIdentifier ('%s'): it is probably invalid", orgId))
 	}
-
-	re := regexp.MustCompile(OrgIdPattern)
-
-	if !re.MatchString(orgIdString) {
-		return errors.New("Cannot parse organizationIdentifier: it is probably invalid")
-	}
-
 	names := re.SubexpNames()
-	match := re.FindStringSubmatch(orgIdString)
-
+	match := re.FindStringSubmatch(orgId)
 	// Initialize a map to hold group names and values
 	result := make(map[string]string)
-
 	// Populate the map
 	for i, name := range names {
 		if i != 0 && name != "" { // Skip the whole match and unnamed groups
 			result[name] = match[i]
 		}
 	}
+	o.Scheme = result["scheme"]
+	o.Country = result["country"]
+	o.State = result["state"]
+	o.Reference = result["reference"]
+	return o, nil
+}
 
-	orgId.Scheme = result["scheme"]
-	orgId.Country = result["country"]
-	orgId.State = result["state"]
-	orgId.Reference = result["reference"]
-
-	return nil
+func (o OrganizationIdentifier) regexForOrgID() *regexp.Regexp {
+	// This is according to the EVG (stricter than ETSI EN 319 412-1)
+	const OrgIdPattern = `^(?P<scheme>[A-Z]{3})(?P<country>[A-Z]{2})(?:\+(?P<state>[A-Z]{2}))?\-(?P<reference>.+)$`
+	const PsdOrgIdPattern = `^(?P<scheme>[A-Z]{3})(?P<country>[A-Z]{2})(?:\+(?P<state>[A-Z]{2}))?\-(?P<nca>[A-Z]*)\-(?P<reference>.+)$`
+	var pattern string
+	if o.ParseAsPSD {
+		pattern = PsdOrgIdPattern
+	} else {
+		pattern = OrgIdPattern
+	}
+	return regexp.MustCompile(pattern)
 }
 
 type orgIdInconsistentSubjAndExt struct{}
@@ -101,8 +101,7 @@ func (l *orgIdInconsistentSubjAndExt) CheckApplies(c *x509.Certificate) bool {
 
 func (l *orgIdInconsistentSubjAndExt) Execute(c *x509.Certificate) *lint.LintResult {
 	// It should be safe to assume there is only one element in OrganizationIDs
-	var orgId OrganizationIdentifier
-	err := ParseOrgId(c.Subject.OrganizationIDs[0], &orgId, false)
+	orgId, err := OrganizationIdentifier{ParseAsPSD: false}.Parse(c.Subject.OrganizationIDs[0])
 	if err != nil {
 		return &lint.LintResult{
 			Status:  lint.Error,
@@ -121,18 +120,17 @@ func (l *orgIdInconsistentSubjAndExt) Execute(c *x509.Certificate) *lint.LintRes
 				Details: "CABFOrganizationIdentifier is NOT consistent with organizationIdentifier"}
 		}
 
-		//Now check PSD2 without an NCA in the registrationReference
-		err := ParseOrgId(c.Subject.OrganizationIDs[0], &orgId, true)
+		psdOrgId, err := OrganizationIdentifier{ParseAsPSD: true}.Parse(c.Subject.OrganizationIDs[0])
 		if err != nil {
 			return &lint.LintResult{
 				Status:  lint.Error,
 				Details: "the organizationIdentifier Subject attribute probably has an invalid value"}
 		}
 
-		if (c.CABFOrganizationIdentifier.Scheme != orgId.Scheme) ||
-			(c.CABFOrganizationIdentifier.Country != orgId.Country) ||
-			(c.CABFOrganizationIdentifier.State != orgId.State) ||
-			(c.CABFOrganizationIdentifier.Reference != orgId.Reference) {
+		if (c.CABFOrganizationIdentifier.Scheme != psdOrgId.Scheme) ||
+			(c.CABFOrganizationIdentifier.Country != psdOrgId.Country) ||
+			(c.CABFOrganizationIdentifier.State != psdOrgId.State) ||
+			(c.CABFOrganizationIdentifier.Reference != psdOrgId.Reference) {
 
 			return &lint.LintResult{
 				Status:  lint.Error,

--- a/v3/lints/cabf_ev/lint_ev_orgid_inconsistent_subj_and_ext.go
+++ b/v3/lints/cabf_ev/lint_ev_orgid_inconsistent_subj_and_ext.go
@@ -21,11 +21,11 @@ package cabf_ev
 
 import (
 	"fmt"
+
 	"github.com/zmap/zcrypto/x509"
 	"github.com/zmap/zlint/v3/lint"
 	"github.com/zmap/zlint/v3/util"
 
-	"errors"
 	"regexp"
 )
 
@@ -54,7 +54,7 @@ type OrganizationIdentifier struct {
 func (o OrganizationIdentifier) Parse(orgId string) (OrganizationIdentifier, error) {
 	re := o.regexForOrgID()
 	if !re.MatchString(orgId) {
-		return o, errors.New(fmt.Sprintf("Cannot parse organizationIdentifier ('%s'): it is probably invalid", orgId))
+		return o, fmt.Errorf("Cannot parse organizationIdentifier ('%s'): it is probably invalid", orgId)
 	}
 	names := re.SubexpNames()
 	match := re.FindStringSubmatch(orgId)


### PR DESCRIPTION
* Moved parsing logic into a so called "parse constructor"
  * Users construct either a `OrganizationIdentifier{ParseAsPSD: false}` or `OrganizationIdentifier{ParseAsPSD: true}` and then calls `Parse` on that variant to populate the struct from the given string.